### PR TITLE
Add the ability to always show markers/trails on the (mini)map

### DIFF
--- a/Entity/StandardMarker.MiniMap.cs
+++ b/Entity/StandardMarker.MiniMap.cs
@@ -17,12 +17,16 @@ namespace BhModule.Community.Pathing.Entity {
             if (IsFiltered(EntityRenderTarget.Map) || this.Texture == null) return null;
 
             bool isMapOpen = GameService.Gw2Mumble.UI.IsMapOpen;
+            
+            // TODO: Make this more simple
 
-            var mapShowMarkersOnFullscreen = _packState.UserConfiguration.MapShowMarkersOnFullscreen.Value;
-            if (mapShowMarkersOnFullscreen != VisibilityLevel.Always && (!this.MapVisibility || mapShowMarkersOnFullscreen == VisibilityLevel.Never) && isMapOpen) return null;
+            var  mapShowMarkersOnFullscreen = _packState.UserConfiguration.MapShowMarkersOnFullscreen.Value;
+            bool allowedOnMap               = this.MapVisibility && mapShowMarkersOnFullscreen != VisibilityLevel.Never;
+            if (isMapOpen && !allowedOnMap && mapShowMarkersOnFullscreen != VisibilityLevel.Always) return null;
 
-            var mapShowMarkersOnCompass = _packState.UserConfiguration.MapShowMarkersOnCompass.Value;
-            if (mapShowMarkersOnCompass != VisibilityLevel.Always && (!this.MiniMapVisibility || mapShowMarkersOnCompass == VisibilityLevel.Never) && !isMapOpen) return null;
+            var  mapShowMarkersOnCompass = _packState.UserConfiguration.MapShowMarkersOnCompass.Value;
+            bool allowedOnMiniMap        = this.MiniMapVisibility && mapShowMarkersOnCompass != VisibilityLevel.Never;
+            if (!isMapOpen && !allowedOnMiniMap && mapShowMarkersOnCompass != VisibilityLevel.Always) return null;
 
             var location = GetScaledLocation(this.Position.X, this.Position.Y, scale, offsets);
 

--- a/Entity/StandardMarker.MiniMap.cs
+++ b/Entity/StandardMarker.MiniMap.cs
@@ -16,8 +16,13 @@ namespace BhModule.Community.Pathing.Entity {
         public override RectangleF? RenderToMiniMap(SpriteBatch spriteBatch, Rectangle bounds, (double X, double Y) offsets, double scale, float opacity) {
             if (IsFiltered(EntityRenderTarget.Map) || this.Texture == null) return null;
 
-            if ((!this.MapVisibility     || !_packState.UserConfiguration.MapShowMarkersOnFullscreen.Value) && GameService.Gw2Mumble.UI.IsMapOpen) return null;
-            if ((!this.MiniMapVisibility || !_packState.UserConfiguration.MapShowMarkersOnCompass.Value)    && !GameService.Gw2Mumble.UI.IsMapOpen) return null;
+            bool isMapOpen = GameService.Gw2Mumble.UI.IsMapOpen;
+
+            var mapShowMarkersOnFullscreen = _packState.UserConfiguration.MapShowMarkersOnFullscreen.Value;
+            if (mapShowMarkersOnFullscreen != VisibilityLevel.Always && (!this.MapVisibility || mapShowMarkersOnFullscreen == VisibilityLevel.Never) && isMapOpen) return null;
+
+            var mapShowMarkersOnCompass = _packState.UserConfiguration.MapShowMarkersOnCompass.Value;
+            if (mapShowMarkersOnCompass != VisibilityLevel.Always && (!this.MiniMapVisibility || mapShowMarkersOnCompass == VisibilityLevel.Never) && !isMapOpen) return null;
 
             var location = GetScaledLocation(this.Position.X, this.Position.Y, scale, offsets);
 

--- a/Entity/StandardMarker.MiniMap.cs
+++ b/Entity/StandardMarker.MiniMap.cs
@@ -20,13 +20,13 @@ namespace BhModule.Community.Pathing.Entity {
             
             // TODO: Make this more simple
 
-            var  mapShowMarkersOnFullscreen = _packState.UserConfiguration.MapShowMarkersOnFullscreen.Value;
-            bool allowedOnMap               = this.MapVisibility && mapShowMarkersOnFullscreen != VisibilityLevel.Never;
-            if (isMapOpen && !allowedOnMap && mapShowMarkersOnFullscreen != VisibilityLevel.Always) return null;
+            var  mapMarkerVisibilityLevel = _packState.UserConfiguration.MapMarkerVisibilityLevel.Value;
+            bool allowedOnMap             = this.MapVisibility && mapMarkerVisibilityLevel != VisibilityLevel.Never;
+            if (isMapOpen && !allowedOnMap && mapMarkerVisibilityLevel != VisibilityLevel.Always) return null;
 
-            var  mapShowMarkersOnCompass = _packState.UserConfiguration.MapShowMarkersOnCompass.Value;
-            bool allowedOnMiniMap        = this.MiniMapVisibility && mapShowMarkersOnCompass != VisibilityLevel.Never;
-            if (!isMapOpen && !allowedOnMiniMap && mapShowMarkersOnCompass != VisibilityLevel.Always) return null;
+            var  miniMapMarkerVisibilityLevel = _packState.UserConfiguration.MiniMapMarkerVisibilityLevel.Value;
+            bool allowedOnMiniMap             = this.MiniMapVisibility && miniMapMarkerVisibilityLevel != VisibilityLevel.Never;
+            if (!isMapOpen && !allowedOnMiniMap && miniMapMarkerVisibilityLevel != VisibilityLevel.Always) return null;
 
             var location = GetScaledLocation(this.Position.X, this.Position.Y, scale, offsets);
 

--- a/Entity/StandardTrail.MiniMap.cs
+++ b/Entity/StandardTrail.MiniMap.cs
@@ -12,11 +12,15 @@ namespace BhModule.Community.Pathing.Entity {
 
             bool isMapOpen = GameService.Gw2Mumble.UI.IsMapOpen;
 
-            var mapShowTrailsOnFullscreen = _packState.UserConfiguration.MapShowTrailsOnFullscreen.Value;
-            if (mapShowTrailsOnFullscreen != VisibilityLevel.Always && (!this.MapVisibility || mapShowTrailsOnFullscreen == VisibilityLevel.Never) && isMapOpen) return null;
+            // TODO: Make this more simple
 
-            var mapShowTrailOnCompass = _packState.UserConfiguration.MapShowTrailsOnCompass.Value;
-            if (mapShowTrailOnCompass != VisibilityLevel.Always && (!this.MiniMapVisibility || mapShowTrailOnCompass == VisibilityLevel.Never) && !isMapOpen) return null;
+            var  mapShowTrailsOnFullscreen = _packState.UserConfiguration.MapShowTrailsOnFullscreen.Value;
+            bool allowedOnMap              = this.MapVisibility && mapShowTrailsOnFullscreen != VisibilityLevel.Never;
+            if (isMapOpen && !allowedOnMap && mapShowTrailsOnFullscreen != VisibilityLevel.Always) return null;
+
+            var  mapShowTrailOnCompass = _packState.UserConfiguration.MapShowTrailsOnCompass.Value;
+            bool allowedOnMiniMap      = this.MiniMapVisibility && mapShowTrailOnCompass != VisibilityLevel.Never;
+            if (!isMapOpen && !allowedOnMiniMap && mapShowTrailOnCompass != VisibilityLevel.Always) return null;
 
             bool lastPointInBounds = false;
 

--- a/Entity/StandardTrail.MiniMap.cs
+++ b/Entity/StandardTrail.MiniMap.cs
@@ -10,8 +10,13 @@ namespace BhModule.Community.Pathing.Entity {
         public override RectangleF? RenderToMiniMap(SpriteBatch spriteBatch, Rectangle bounds, (double X, double Y) offsets, double scale, float opacity) {
             if (IsFiltered(EntityRenderTarget.Map) || this.Texture == null) return null;
 
-            if ((!this.MapVisibility     || !_packState.UserConfiguration.MapShowTrailsOnFullscreen.Value) && GameService.Gw2Mumble.UI.IsMapOpen) return null;
-            if ((!this.MiniMapVisibility || !_packState.UserConfiguration.MapShowTrailsOnCompass.Value)   && !GameService.Gw2Mumble.UI.IsMapOpen) return null;
+            bool isMapOpen = GameService.Gw2Mumble.UI.IsMapOpen;
+
+            var mapShowTrailsOnFullscreen = _packState.UserConfiguration.MapShowTrailsOnFullscreen.Value;
+            if (mapShowTrailsOnFullscreen != VisibilityLevel.Always && (!this.MapVisibility || mapShowTrailsOnFullscreen == VisibilityLevel.Never) && isMapOpen) return null;
+
+            var mapShowTrailOnCompass = _packState.UserConfiguration.MapShowTrailsOnCompass.Value;
+            if (mapShowTrailOnCompass != VisibilityLevel.Always && (!this.MiniMapVisibility || mapShowTrailOnCompass == VisibilityLevel.Never) && !isMapOpen) return null;
 
             bool lastPointInBounds = false;
 

--- a/Entity/StandardTrail.MiniMap.cs
+++ b/Entity/StandardTrail.MiniMap.cs
@@ -14,13 +14,13 @@ namespace BhModule.Community.Pathing.Entity {
 
             // TODO: Make this more simple
 
-            var  mapShowTrailsOnFullscreen = _packState.UserConfiguration.MapShowTrailsOnFullscreen.Value;
-            bool allowedOnMap              = this.MapVisibility && mapShowTrailsOnFullscreen != VisibilityLevel.Never;
-            if (isMapOpen && !allowedOnMap && mapShowTrailsOnFullscreen != VisibilityLevel.Always) return null;
+            var  mapTrailVisibilityLevel = _packState.UserConfiguration.MapTrailVisibilityLevel.Value;
+            bool allowedOnMap            = this.MapVisibility && mapTrailVisibilityLevel != VisibilityLevel.Never;
+            if (isMapOpen && !allowedOnMap && mapTrailVisibilityLevel != VisibilityLevel.Always) return null;
 
-            var  mapShowTrailOnCompass = _packState.UserConfiguration.MapShowTrailsOnCompass.Value;
-            bool allowedOnMiniMap      = this.MiniMapVisibility && mapShowTrailOnCompass != VisibilityLevel.Never;
-            if (!isMapOpen && !allowedOnMiniMap && mapShowTrailOnCompass != VisibilityLevel.Always) return null;
+            var  miniMapTrailVisibilityLevel = _packState.UserConfiguration.MiniMapTrailVisibilityLevel.Value;
+            bool allowedOnMiniMap            = this.MiniMapVisibility && miniMapTrailVisibilityLevel != VisibilityLevel.Never;
+            if (!isMapOpen && !allowedOnMiniMap && miniMapTrailVisibilityLevel != VisibilityLevel.Always) return null;
 
             bool lastPointInBounds = false;
 

--- a/ModuleSettings.cs
+++ b/ModuleSettings.cs
@@ -9,6 +9,12 @@ namespace BhModule.Community.Pathing {
         OnlyWhenInteractedWith,
         Never
     }
+    
+    public enum VisibilityLevel {
+        Default,
+        Always,
+        Never
+    }
 
     public class ModuleSettings {
 
@@ -83,26 +89,26 @@ namespace BhModule.Community.Pathing {
 
         public SettingCollection MapSettings { get; private set; }
 
-        public SettingEntry<bool> MapPathablesEnabled                   { get; private set; }
-        public SettingEntry<bool> MapShowMarkersOnFullscreen            { get; private set; }
-        public SettingEntry<bool> MapShowTrailsOnFullscreen             { get; private set; }
-        public SettingEntry<bool> MapShowMarkersOnCompass               { get; private set; }
-        public SettingEntry<bool> MapShowTrailsOnCompass                { get; private set; }    
-        public SettingEntry<bool> MapShowAboveBelowIndicators           { get; private set; }
-        public SettingEntry<bool> MapFadeVerticallyDistantTrailSegments { get; private set; }
+        public SettingEntry<bool>            MapPathablesEnabled                   { get; private set; }
+        public SettingEntry<VisibilityLevel> MapShowMarkersOnFullscreen            { get; private set; }
+        public SettingEntry<VisibilityLevel> MapShowTrailsOnFullscreen             { get; private set; }
+        public SettingEntry<VisibilityLevel> MapShowMarkersOnCompass               { get; private set; }
+        public SettingEntry<VisibilityLevel> MapShowTrailsOnCompass                { get; private set; }
+        public SettingEntry<bool>            MapShowAboveBelowIndicators           { get; private set; }
+        public SettingEntry<bool>            MapFadeVerticallyDistantTrailSegments { get; private set; }
 
         private void InitMapSettings(SettingCollection settings) {
             this.MapSettings = settings.AddSubCollection(MAP_SETTINGS);
 
             // TODO: Add string to strings.resx for localization.
             // TODO: Add description to settings.
-            this.MapPathablesEnabled                   = this.MapSettings.DefineSetting(nameof(this.MapPathablesEnabled),                   true, () => "Show Markers on Maps");
-            this.MapShowMarkersOnFullscreen            = this.MapSettings.DefineSetting(nameof(this.MapShowMarkersOnFullscreen),            true, () => Strings.Setting_MapShowMarkersOnFullscreen,  () => "");
-            this.MapShowTrailsOnFullscreen             = this.MapSettings.DefineSetting(nameof(this.MapShowTrailsOnFullscreen),             true, () => Strings.Setting_MapShowTrailsOnFullscreen,   () => "");
-            this.MapShowMarkersOnCompass               = this.MapSettings.DefineSetting(nameof(this.MapShowMarkersOnCompass),               true, () => Strings.Setting_MapShowMarkersOnCompass,     () => "");
-            this.MapShowTrailsOnCompass                = this.MapSettings.DefineSetting(nameof(this.MapShowTrailsOnCompass),                true, () => Strings.Setting_MapShowTrailsOnCompass,      () => "");
-            this.MapShowAboveBelowIndicators           = this.MapSettings.DefineSetting(nameof(this.MapShowAboveBelowIndicators),           true, () => Strings.Setting_MapShowAboveBelowIndicators, () => "");
-            this.MapFadeVerticallyDistantTrailSegments = this.MapSettings.DefineSetting(nameof(this.MapFadeVerticallyDistantTrailSegments), true, () => "Fade Trail Segments Which Are High Above or Below");
+            this.MapPathablesEnabled                   = this.MapSettings.DefineSetting(nameof(this.MapPathablesEnabled),                   true,                    () => "Show Markers on Maps");
+            this.MapShowMarkersOnFullscreen            = this.MapSettings.DefineSetting(nameof(this.MapShowMarkersOnFullscreen),            VisibilityLevel.Default, () => Strings.Setting_MapShowMarkersOnFullscreen,  () => "");
+            this.MapShowTrailsOnFullscreen             = this.MapSettings.DefineSetting(nameof(this.MapShowTrailsOnFullscreen),             VisibilityLevel.Default, () => Strings.Setting_MapShowTrailsOnFullscreen,   () => "");
+            this.MapShowMarkersOnCompass               = this.MapSettings.DefineSetting(nameof(this.MapShowMarkersOnCompass),               VisibilityLevel.Default, () => Strings.Setting_MapShowMarkersOnCompass,     () => "");
+            this.MapShowTrailsOnCompass                = this.MapSettings.DefineSetting(nameof(this.MapShowTrailsOnCompass),                VisibilityLevel.Default, () => Strings.Setting_MapShowTrailsOnCompass,      () => "");
+            this.MapShowAboveBelowIndicators           = this.MapSettings.DefineSetting(nameof(this.MapShowAboveBelowIndicators),           true,                    () => Strings.Setting_MapShowAboveBelowIndicators, () => "");
+            this.MapFadeVerticallyDistantTrailSegments = this.MapSettings.DefineSetting(nameof(this.MapFadeVerticallyDistantTrailSegments), true,                    () => "Fade Trail Segments Which Are High Above or Below");
         }
 
         #endregion

--- a/ModuleSettings.cs
+++ b/ModuleSettings.cs
@@ -90,10 +90,10 @@ namespace BhModule.Community.Pathing {
         public SettingCollection MapSettings { get; private set; }
 
         public SettingEntry<bool>            MapPathablesEnabled                   { get; private set; }
-        public SettingEntry<VisibilityLevel> MapShowMarkersOnFullscreen            { get; private set; }
-        public SettingEntry<VisibilityLevel> MapShowTrailsOnFullscreen             { get; private set; }
-        public SettingEntry<VisibilityLevel> MapShowMarkersOnCompass               { get; private set; }
-        public SettingEntry<VisibilityLevel> MapShowTrailsOnCompass                { get; private set; }
+        public SettingEntry<VisibilityLevel> MapMarkerVisibilityLevel              { get; private set; }
+        public SettingEntry<VisibilityLevel> MapTrailVisibilityLevel               { get; private set; }
+        public SettingEntry<VisibilityLevel> MiniMapMarkerVisibilityLevel          { get; private set; }
+        public SettingEntry<VisibilityLevel> MiniMapTrailVisibilityLevel           { get; private set; }
         public SettingEntry<bool>            MapShowAboveBelowIndicators           { get; private set; }
         public SettingEntry<bool>            MapFadeVerticallyDistantTrailSegments { get; private set; }
 
@@ -103,10 +103,10 @@ namespace BhModule.Community.Pathing {
             // TODO: Add string to strings.resx for localization.
             // TODO: Add description to settings.
             this.MapPathablesEnabled                   = this.MapSettings.DefineSetting(nameof(this.MapPathablesEnabled),                   true,                    () => "Show Markers on Maps");
-            this.MapShowMarkersOnFullscreen            = this.MapSettings.DefineSetting(nameof(this.MapShowMarkersOnFullscreen),            VisibilityLevel.Default, () => Strings.Setting_MapShowMarkersOnFullscreen,  () => "");
-            this.MapShowTrailsOnFullscreen             = this.MapSettings.DefineSetting(nameof(this.MapShowTrailsOnFullscreen),             VisibilityLevel.Default, () => Strings.Setting_MapShowTrailsOnFullscreen,   () => "");
-            this.MapShowMarkersOnCompass               = this.MapSettings.DefineSetting(nameof(this.MapShowMarkersOnCompass),               VisibilityLevel.Default, () => Strings.Setting_MapShowMarkersOnCompass,     () => "");
-            this.MapShowTrailsOnCompass                = this.MapSettings.DefineSetting(nameof(this.MapShowTrailsOnCompass),                VisibilityLevel.Default, () => Strings.Setting_MapShowTrailsOnCompass,      () => "");
+            this.MapMarkerVisibilityLevel              = this.MapSettings.DefineSetting(nameof(this.MapMarkerVisibilityLevel),              VisibilityLevel.Default, () => Strings.Setting_MapShowMarkersOnFullscreen,  () => "");
+            this.MapTrailVisibilityLevel               = this.MapSettings.DefineSetting(nameof(this.MapTrailVisibilityLevel),               VisibilityLevel.Default, () => Strings.Setting_MapShowTrailsOnFullscreen,   () => "");
+            this.MiniMapMarkerVisibilityLevel          = this.MapSettings.DefineSetting(nameof(this.MiniMapMarkerVisibilityLevel),          VisibilityLevel.Default, () => Strings.Setting_MapShowMarkersOnCompass,     () => "");
+            this.MiniMapTrailVisibilityLevel           = this.MapSettings.DefineSetting(nameof(this.MiniMapTrailVisibilityLevel),           VisibilityLevel.Default, () => Strings.Setting_MapShowTrailsOnCompass,      () => "");
             this.MapShowAboveBelowIndicators           = this.MapSettings.DefineSetting(nameof(this.MapShowAboveBelowIndicators),           true,                    () => Strings.Setting_MapShowAboveBelowIndicators, () => "");
             this.MapFadeVerticallyDistantTrailSegments = this.MapSettings.DefineSetting(nameof(this.MapFadeVerticallyDistantTrailSegments), true,                    () => "Fade Trail Segments Which Are High Above or Below");
         }


### PR DESCRIPTION
This commit changes the `MapShowMarkersOnFullscreen`/`MapShowTrailsOnFullscreen`/`MapShowMarkersOnCompass`/`MapShowTrailsOnCompass` settings to enums, which allows you to force the markers/trails to always be visible on the (mini)map.

![image](https://user-images.githubusercontent.com/42659/132993970-56352d06-8e4e-4a4a-ae55-361f2a222624.png)

This is particularly useful with Teh's Map Completion trails which have `miniMapVisibility="0"`, but I still find it nice to be able to see them on the minimap.

![image](https://user-images.githubusercontent.com/42659/132993854-32efdd6d-27bc-4f45-a4e9-f3566928a273.png)
