### PR TITLE
Re-enable and fix `ScaleOnMapWithZoom` (Fix #60)

### DIFF
--- a/Entity/StandardMarker.MiniMap.cs
+++ b/Entity/StandardMarker.MiniMap.cs
@@ -27,14 +27,15 @@ namespace BhModule.Community.Pathing.Entity {
             bool allowedOnMiniMap             = this.MiniMapVisibility && miniMapMarkerVisibilityLevel != MapVisibilityLevel.Never;
             if (!isMapOpen && !allowedOnMiniMap && miniMapMarkerVisibilityLevel != MapVisibilityLevel.Always) return null;
 
-            if (!this.ScaleOnMapWithZoom) {
-                // Zoom scaling is disabled, so we override back to 1.
-                scale = 1f;
-            }
-
             var location = GetScaledLocation(this.Position.X, this.Position.Y, scale, offsets);
 
             if (!bounds.Contains(location)) return null;
+
+            if (!this.ScaleOnMapWithZoom) {
+                // Zoom scaling is disabled, so we override back to 1
+                // Only do this after setting the location
+                scale = 1f;
+            }
 
             float drawScale = (float)(1f / scale);
 

--- a/Entity/StandardMarker[mapdisplaysize,scaleonmapwithzoom].cs
+++ b/Entity/StandardMarker[mapdisplaysize,scaleonmapwithzoom].cs
@@ -21,7 +21,7 @@ namespace BhModule.Community.Pathing.Entity {
             this.ScaleOnMapWithZoom = _packState.UserResourceStates.Population.MarkerPopulationDefaults.ScaleOnMapWithZoom;
 
             { if (collection.TryPopAttribute(ATTR_MAPDISPLAYSIZE,     out var attribute)) this.MapDisplaySize     = attribute.GetValueAsFloat(this.MapDisplaySize); }
-            //{ if (collection.TryPopAttribute(ATTR_SCALEONMAPWITHZOOM, out var attribute)) this.ScaleOnMapWithZoom = attribute.GetValueAsBool(); }
+            { if (collection.TryPopAttribute(ATTR_SCALEONMAPWITHZOOM, out var attribute)) this.ScaleOnMapWithZoom = attribute.GetValueAsBool(); }
         }
 
     }


### PR DESCRIPTION
The location must still be scaled, even if the size isn't. So this change just flips the order of statements so that the overriding of the scale occurs only after the location is set.

It also re-enables the functionality in general.