### PR TITLE
Add AchievementBit info to Category menus. Text type only for now.

### DIFF
--- a/UI/Controls/CategoryContextMenuStripItem.cs
+++ b/UI/Controls/CategoryContextMenuStripItem.cs
@@ -72,16 +72,25 @@ namespace BhModule.Community.Pathing.UI.Controls {
         private void DetectAndBuildContexts() {
             if (_pathingCategory.TryGetAggregatedAttributeValue(AchievementFilter.ATTR_ID, out var achievementAttr)) {
 
+                var achievementBit = -1;
+                if (_pathingCategory.TryGetAggregatedAttributeValue(AchievementFilter.ATTR_BIT, out var achievementBitAttr))
+                {
+                    if (InvariantUtil.TryParseInt(achievementBitAttr, out int achievementBitParsed))
+                    {
+                        achievementBit = achievementBitParsed;
+                    }
+                }
+
                 // TODO: Add as a context so that multiple characteristics can be accounted for.
 
                 if (!InvariantUtil.TryParseInt(achievementAttr, out int achievementId)) return;
 
                 if (achievementId < 0) return;
 
-                this.Tooltip = new Tooltip(new AchievementTooltipView(achievementId));
+                this.Tooltip = new Tooltip(new AchievementTooltipView(achievementId, achievementBit));
 
                 if (_packState.UserConfiguration.PackAllowMarkersToAutomaticallyHide.Value) {
-                    this.Enabled = !_packState.AchievementStates.IsAchievementHidden(achievementId, -1);
+                    this.Enabled = !_packState.AchievementStates.IsAchievementHidden(achievementId, achievementBit);
 
                     if (!this.Enabled) {
                         this.Checked = false;

--- a/UI/Tooltips/AchievementTooltipView.cs
+++ b/UI/Tooltips/AchievementTooltipView.cs
@@ -12,6 +12,7 @@ namespace BhModule.Community.Pathing.UI.Tooltips {
     public class AchievementTooltipView : View, ITooltipView {
 
         private Achievement _achievement;
+        private int _achievementBit;
         public Achievement Achievement {
             get => _achievement;
             set {
@@ -40,8 +41,9 @@ namespace BhModule.Community.Pathing.UI.Tooltips {
 
         public AchievementTooltipView() { /* NOOP */ }
 
-        public AchievementTooltipView(int achievementId) {
+        public AchievementTooltipView(int achievementId, int achievementBit) {
             this.WithPresenter(new AchievementPresenter(this, achievementId));
+            this._achievementBit = achievementBit;
         }
 
         protected override void Build(Container buildPanel) {
@@ -103,6 +105,15 @@ namespace BhModule.Community.Pathing.UI.Tooltips {
             _achievementNameLabel.Text        = _achievement.Name;
             _achievementDescriptionLabel.Text = CleanMessage(_achievement.Description);
             _achievementRequirementLabel.Text = CleanMessage(_achievement.Requirement);
+           
+            if (_achievementBit != -1)
+            {
+                var bit = _achievement.Bits[_achievementBit];
+                if (bit.Type == AchievementBitType.Text)
+                {
+                    _achievementRequirementLabel.Text = CleanMessage(((AchievementTextBit) bit).Text);
+                }
+            }
 
             _achievementNameLabel.Height       = string.IsNullOrEmpty(_achievement.Description) ? _categoryIconImage.Height : _categoryIconImage.Height / 2;
             _achievementDescriptionLabel.Width = Math.Max(_achievementNameLabel.Width, 200);


### PR DESCRIPTION
I saw that #50 was open after noticing that categories tied to a specific `achievementBit` were not being marked as completed in the menu, even if they were actually being hidden in world rendering.

I also made the Tooltip show the Requirement text for bits that are of type Text for now.

Not sure if this is the best code, but it works! Let me know if I should change anything. Or even, maybe leaving the tooltip stuff for another PR?

This is what I wanted to accomplish:
![image](https://user-images.githubusercontent.com/11269035/162497278-ecdf322d-52a2-4b2c-8993-eb58a9560d5c.png)

