### PR TITLE
Add fix for float parsing in de-DE culture

### DIFF
--- a/Scripting/Lib/Instance.cs
+++ b/Scripting/Lib/Instance.cs
@@ -36,7 +36,7 @@ namespace BhModule.Community.Pathing.Scripting.Lib {
         // Marker
 
         private AttributeCollection AttributeCollectionFromLuaTable(LuaTable luaTable) {
-            return new AttributeCollection(luaTable.Members.Select(member => new Attribute(member.Key, member.Value.ToString())));
+            return new AttributeCollection(luaTable.Members.Select(member => new Attribute(member.Key, string.Format(CultureInfo.InvariantCulture, "{0}", member.Value))));
         }
 
         public StandardMarker Marker(IPackResourceManager resourceManager, LuaTable attributes = null) {

--- a/Scripting/Lib/Instance.cs
+++ b/Scripting/Lib/Instance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using BhModule.Community.Pathing.Content;
 using BhModule.Community.Pathing.Entity;


### PR DESCRIPTION
[Discussion Reference](https://discord.com/channels/531175899588984842/599270434642460753/1116887243274063873)

Breaking change: no

The AttributeCollection was serialising values from the LuaTable using the CurrentCulture, this lead to `0.5` in Lua scripts being read in as `"0,5"` in some cultures, then deserialised again using InvariantCulture, sometimes failing or producing invalid values.