### PR TITLE
Category Explorer changes

### DIFF
--- a/PackInitiator.cs
+++ b/PackInitiator.cs
@@ -151,7 +151,7 @@ namespace BhModule.Community.Pathing {
             var searchMarkers = new ContextMenuStripItem()
             {
                 Text = "Search",
-                BackgroundColor = Color.Yellow * 0.1f
+                BackgroundColor = Color.LightBlue * 0.1f
             };
 
 

--- a/PackInitiator.cs
+++ b/PackInitiator.cs
@@ -144,13 +144,36 @@ namespace BhModule.Community.Pathing {
                              && _sharedPackCollection.Categories != null
                              && _sharedPackCollection.Categories.Any(category => !string.IsNullOrWhiteSpace(category.DisplayName));
 
+            var markerSubMenu = isAnyMarkers
+                                    ? new CategoryContextMenuStrip(_packState, _sharedPackCollection.Categories, false)
+                                    : null;
+
+            var searchMarkers = new ContextMenuStripItem()
+            {
+                Text = "Search",
+                BackgroundColor = Color.Yellow * 0.1f
+            };
+
+
+            searchMarkers.Click += (_, _) => {
+                if (PathingModule.Instance.SettingsWindow.SelectedTab != PathingModule.Instance.CategoryTreeTab)
+                {
+                    PathingModule.Instance.SettingsWindow.SelectedTab = PathingModule.Instance.CategoryTreeTab;
+
+                    if (PathingModule.Instance.SettingsWindow.Visible) return;
+                }
+
+                PathingModule.Instance.SettingsWindow.ToggleWindow();
+            };
+
+            if (markerSubMenu != null)
+                markerSubMenu.AddMenuItem(searchMarkers);
+
             var allMarkers = new ContextMenuStripItem() {
                 Text = "All Markers", // TODO: Localize "All Markers"
                 CanCheck = true,
                 Checked = _module.Settings.GlobalPathablesEnabled.Value,
-                Submenu = isAnyMarkers
-                    ? new CategoryContextMenuStrip(_packState, _sharedPackCollection.Categories, false)
-                    : null
+                Submenu = markerSubMenu
             };
 
             allMarkers.CheckedChanged += (_, e) => {

--- a/Pathing.csproj
+++ b/Pathing.csproj
@@ -309,6 +309,7 @@
     <Compile Include="UI\Effects\AlphaMaskEffect.cs" />
     <Compile Include="UI\Presenters\PackRepoPresenter.cs" />
     <Compile Include="UI\Presenters\SettingsHintPresenter.cs" />
+    <Compile Include="UI\Views\ConfirmationView.cs" />
     <Compile Include="UI\Views\AdvancedCategoryView.cs" />
     <Compile Include="UI\Views\IndividualPackSettingsView.cs" />
     <Compile Include="UI\Views\CategoryTreeView.cs" />

--- a/Pathing.csproj
+++ b/Pathing.csproj
@@ -278,6 +278,7 @@
     <Compile Include="UI\Controls\NodeTree\PathingNode.cs" />
     <Compile Include="UI\Events\PathingCategoryEventArgs.cs" />
     <Compile Include="UI\Models\PathingTexture.cs" />
+    <Compile Include="UI\Tooltips\CategoryPathTooltip.cs" />
     <Compile Include="UI\Tooltips\EntityTextureTooltip.cs" />
     <Compile Include="UI\Controls\CustomFlowPanel.cs" />
     <Compile Include="UI\Controls\NodeTree\PathingCategoryNode.cs" />

--- a/PathingModule.cs
+++ b/PathingModule.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using BhModule.Community.Pathing.Entity;
 using BhModule.Community.Pathing.Scripting;
 using BhModule.Community.Pathing.Scripting.Console;
-using BhModule.Community.Pathing.UI.Controls.TreeView;
 using BhModule.Community.Pathing.UI.Events;
 using BhModule.Community.Pathing.UI.Views;
 using Blish_HUD.Controls;

--- a/State/CategoryStates.cs
+++ b/State/CategoryStates.cs
@@ -35,6 +35,7 @@ namespace BhModule.Community.Pathing.State {
         private bool _calculationDirty = false;
 
         public event EventHandler<PathingCategoryEventArgs> CategoryInactiveChanged;
+        public event EventHandler<EventArgs> CategoryStatesOptimized;
 
         public CategoryStates(IRootPackState packState) : base(packState) { /* NOOP */ }
 
@@ -156,6 +157,8 @@ namespace BhModule.Community.Pathing.State {
             }
 
             _inactiveCategories = preCalcInactiveCategories;
+            this.CategoryStatesOptimized?.Invoke(this, EventArgs.Empty);
+
             _calculationDirty = false;
         }
 
@@ -184,6 +187,11 @@ namespace BhModule.Community.Pathing.State {
 
         public bool GetNamespaceInactive(string categoryNamespace) {
             return _inactiveCategories.Contains(categoryNamespace);
+        }
+
+        public bool GetRawNamespaceInactive(string categoryNamespace)
+        {
+            return _rawInactiveCategories.FirstOrDefault(c => c.Namespace.Equals(categoryNamespace)) != null;
         }
 
         private bool GetCategoryInactive(PathingCategory category, SafeList<PathingCategory> rawCategoriesList) {

--- a/UI/Controls/CategoryContextMenuStrip.cs
+++ b/UI/Controls/CategoryContextMenuStrip.cs
@@ -123,7 +123,7 @@ namespace BhModule.Community.Pathing.UI.Controls {
         }
 
         private void ShowAllSkippedCategories_LeftMouseButtonReleased(object sender, MouseEventArgs e) {
-            this.ClearChildren();
+            ClearCategoryStrips();
 
             (IEnumerable<PathingCategory> subCategories, int skipped) = GetSubCategories(true);
 
@@ -137,9 +137,21 @@ namespace BhModule.Community.Pathing.UI.Controls {
                 cmsiChild?.Submenu?.Hide();
             }
 
-            this.ClearChildren();
+            ClearCategoryStrips();
+
 
             base.OnHidden(e);
+        }
+
+        private void ClearCategoryStrips() {
+            var search = this.Children
+                             .OfType<ContextMenuStripItem>()
+                             .FirstOrDefault();
+
+            this.ClearChildren();
+
+            if (search != null)
+                search.Parent = this;
         }
 
         private const int SCROLLHINT_HEIGHT = 20;

--- a/UI/Controls/NodeTree/PathingCategoryNode.cs
+++ b/UI/Controls/NodeTree/PathingCategoryNode.cs
@@ -37,7 +37,8 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
         }
 
         private readonly IPackState      _packState;
-        public           PathingCategory PathingCategory { get; }
+        public  PathingCategory PathingCategory { get; }
+        private PathingCategory PackCategory { get; }
 
         private readonly IList<IPathingEntity> _entities;
 
@@ -47,7 +48,8 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
         private int _achievementBit;
         private bool _achievementHidden;
 
-        public bool IsSearchResult { get; init; }
+        protected Label PackNameControl;
+        public    bool  IsSearchResult { get; init; }
 
         public PathingCategoryNode(IPackState packState, PathingCategory pathingCategory, bool showForceAll) 
             : base(pathingCategory.DisplayName)
@@ -79,7 +81,10 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
                 this.Checked = !_packState.CategoryStates.GetCategoryInactive(pathingCategory);
                 UpdateActiveState(this.Checked);
             }
-                
+
+            PackCategory = PathingCategory.GetParents()
+                                          .LastOrDefault();
+
             this.CheckedChanged += CheckboxOnCheckedChanged;
         }
 
@@ -113,12 +118,35 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
             //Details
             BuildAchievementTexture();
 
+            //Pack name
+            if (IsSearchResult) 
+                BuildPackName();
+
             //Properties
             BuildEntityCount();
 
             //Context menu
             if(this.Menu != null)
                 BuildContextMenu();
+        }
+
+        private void BuildPackName() {
+            if (PackCategory == null) return;
+
+            PackNameControl?.Dispose();
+
+            PackNameControl = new Label
+            {
+                Parent           = _propertiesPanel,
+                Text             = PackCategory.DisplayName,
+                Height           = this.PanelHeight,
+                AutoSizeWidth    = true,
+                Font             = GameService.Content.DefaultFont16,
+                TextColor        = Color.Orange,
+                WrapText         = true,
+                StrokeText       = true,
+                BasicTooltipText = this.BasicTooltipText
+            };
         }
 
         private void BuildAchievementTexture() {

--- a/UI/Controls/NodeTree/PathingCategoryNode.cs
+++ b/UI/Controls/NodeTree/PathingCategoryNode.cs
@@ -6,6 +6,7 @@ using BhModule.Community.Pathing.Entity;
 using BhModule.Community.Pathing.State;
 using BhModule.Community.Pathing.UI.Models;
 using BhModule.Community.Pathing.UI.Tooltips;
+using BhModule.Community.Pathing.UI.Views;
 using BhModule.Community.Pathing.Utility;
 using Blish_HUD;
 using Blish_HUD.Content;
@@ -277,7 +278,7 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
         }
 
         private void BuildOpenInTree() {
-            var stripItem = new ContextMenuStripItem("Open In Category Tree")
+            var stripItem = new ContextMenuStripItem("Open In Explorer")
             {
                 Parent = this.Menu
             };
@@ -298,13 +299,30 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
 
             UpdateActiveState(e.Checked);
 
-            if (!ParentIsActive() && e.Checked)
-            {
-                ScreenNotification.ShowNotification("One or more of the parent categories are inactive.",
-                                                    ScreenNotification.NotificationType.Warning,
-                                                    null,
-                                                    2);
+            if (!ParentIsActive() && e.Checked) {
+                TreeView.SkipNextStateCheck(this);
+                ShowConfirmationWindow();
             }
+        }
+
+        private ViewContainer _confirmationContainer;
+
+        private void ShowConfirmationWindow() {
+            var window = PathingModule.Instance.SettingsWindow;
+
+            _confirmationContainer?.Dispose();
+
+            _confirmationContainer = new ViewContainer
+            {
+                Size     = new Point(400, 400),
+                HeightSizingMode = SizingMode.AutoSize,
+                Location = new Point(window.Location.X + (window.Size.X / 2 - 200), window.Location.Y + (window.Size.Y / 2 - 200)),
+                ZIndex   = int.MaxValue - 2,
+                FadeView = true,
+                Parent   = Graphics.SpriteScreen
+            };
+
+            _confirmationContainer.Show(new ConfirmationView(this.TreeView, this.PathingCategory, _packState));
         }
 
         public void UpdateActiveState(bool active) {

--- a/UI/Controls/NodeTree/PathingCategoryNode.cs
+++ b/UI/Controls/NodeTree/PathingCategoryNode.cs
@@ -120,8 +120,12 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
             BuildAchievementTexture();
 
             //Pack name
-            if (IsSearchResult) 
+            if (IsSearchResult) {
+                LabelControl.MouseEntered += NameControlOnMouseEntered;
+
                 BuildPackName();
+            }
+               
 
             //Properties
             BuildEntityCount();
@@ -148,7 +152,21 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
                 StrokeText       = true,
                 BasicTooltipText = this.BasicTooltipText
             };
+
+            PackNameControl.MouseEntered += NameControlOnMouseEntered;
         }
+
+        private Tooltip _categoryPathTooltip;
+
+        private void NameControlOnMouseEntered(object sender, MouseEventArgs e) {
+            if (_categoryPathTooltip != null) return;
+
+            _categoryPathTooltip = new Tooltip(new CategoryPathTooltip(this.PathingCategory, _packState));
+
+            if (PackNameControl != null) PackNameControl.Tooltip = _categoryPathTooltip;
+            if (LabelControl != null) LabelControl.Tooltip = _categoryPathTooltip;
+        }
+
 
         private void BuildAchievementTexture() {
             if (_achievementId <= 0) return;
@@ -322,7 +340,7 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
                 Parent   = Graphics.SpriteScreen
             };
 
-            _confirmationContainer.Show(new ConfirmationView(this.TreeView, this.PathingCategory, _packState));
+            _confirmationContainer.Show(new ConfirmationView(this.PathingCategory, _packState));
         }
 
         public void UpdateActiveState(bool active) {

--- a/UI/Controls/NodeTree/PathingCategoryNode.cs
+++ b/UI/Controls/NodeTree/PathingCategoryNode.cs
@@ -161,12 +161,22 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
         private void NameControlOnMouseEntered(object sender, MouseEventArgs e) {
             if (_categoryPathTooltip != null) return;
 
+            BuildCategoryPathTooltip();
+        }
+
+        public void InvalidatePath() {
+            _categoryPathTooltip?.Dispose();
+            _categoryPathTooltip = null;
+        }
+
+        private void BuildCategoryPathTooltip() {
+            _categoryPathTooltip?.Dispose();
+
             _categoryPathTooltip = new Tooltip(new CategoryPathTooltip(this.PathingCategory, _packState));
 
             if (PackNameControl != null) PackNameControl.Tooltip = _categoryPathTooltip;
-            if (LabelControl != null) LabelControl.Tooltip = _categoryPathTooltip;
+            if (LabelControl    != null) LabelControl.Tooltip    = _categoryPathTooltip;
         }
-
 
         private void BuildAchievementTexture() {
             if (_achievementId <= 0) return;
@@ -314,6 +324,8 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
             {
                 _packState.CategoryStates.SetInactive(this.PathingCategory, !e.Checked);
             }
+
+            InvalidatePath();
 
             UpdateActiveState(e.Checked);
 

--- a/UI/Controls/NodeTree/PathingCategoryNode.cs
+++ b/UI/Controls/NodeTree/PathingCategoryNode.cs
@@ -393,7 +393,7 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
                        StandardTrail trail => new PathingTexture { Icon   = trail.Texture, Tint  = trail.Tint },
                        _ => null
                    })
-                  .Where(pt => pt != null && uniqueTextures.Add(pt.Icon.Texture));
+                  .Where(pt => pt?.Icon?.Texture != null && uniqueTextures.Add(pt.Icon.Texture));
         }
 
         private void DetectAndBuildContexts() {

--- a/UI/Controls/NodeTree/PathingNode.cs
+++ b/UI/Controls/NodeTree/PathingNode.cs
@@ -110,7 +110,7 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
             {
                 Parent         = this,
                 FlowDirection  = ControlFlowDirection.LeftToRight,
-                Size           = new Point(this.ContentRegion.Width - 220, this.PanelHeight),
+                Size           = new Point(this.ContentRegion.Width - 240, this.PanelHeight),
                 Location       = new Point(28, 1),
                 ControlPadding = new Vector2(5, 0),
                 CanScroll      = false,
@@ -127,8 +127,8 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
             {
                 Parent         = this,
                 FlowDirection  = ControlFlowDirection.RightToLeft,
-                Size           = new Point(200,              this.PanelHeight),
-                Location       = new Point(this.Width - 210, 1),
+                Size           = new Point(220,              this.PanelHeight),
+                Location       = new Point(this.Width - 230, 1),
                 ControlPadding = new Vector2(5, 0),
                 CanScroll      = false,
                 ShowTint       = DevMode 
@@ -137,7 +137,7 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeNodes
 
         protected override void OnResized(ResizedEventArgs e) {
             if(_propertiesPanel != null)
-                _propertiesPanel.Left = e.CurrentSize.X - 210;
+                _propertiesPanel.Left = e.CurrentSize.X - 230;
 
             base.OnResized(e);
         }

--- a/UI/Controls/NodeTree/TreeView.cs
+++ b/UI/Controls/NodeTree/TreeView.cs
@@ -298,6 +298,8 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeView
                 if (node is PathingCategoryNode { IsSearchResult: true, Checkable: true } categoryNode && categoryNode != _skipStateCheckNode) {
                     categoryNode.Checked = !packState.CategoryStates.GetCategoryInactive(categoryNode.PathingCategory);
                     categoryNode.Active = !packState.CategoryStates.GetNamespaceInactive(categoryNode.PathingCategory.Namespace);
+
+                    categoryNode.InvalidatePath();
                 }
             }
 

--- a/UI/Controls/NodeTree/TreeView.cs
+++ b/UI/Controls/NodeTree/TreeView.cs
@@ -18,10 +18,11 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeView
     {
         private Control _scrollToChildControl = null;
 
-        private PathingCategoryNode _rootNode;
-        private static readonly Logger _logger = Logger.GetLogger<TreeView>();
+        private                 PathingCategoryNode _rootNode;
+        private static readonly Logger              _logger = Logger.GetLogger<TreeView>();
+        private                 PathingCategoryNode _skipStateCheckNode;
 
-        public  PackInitiator          PackInitiator  { get; private set; }
+        public PackInitiator          PackInitiator  { get; private set; }
         public  IList<TreeNodeBase>    AllBaseNodes   { get; }      = new List<TreeNodeBase>();
         public  IList<TreeNodeBase>    ChildBaseNodes { get; }      = new List<TreeNodeBase>();
         private IList<PathingCategory> AllCategories  { get; set; } = new List<PathingCategory>();
@@ -149,7 +150,7 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeView
         }
 
         private void GlobalPathablesEnabledOnSettingChanged(object sender, ValueChangedEventArgs<bool> e) {
-            _rootNode.Checked = PackInitiator.PackState.UserConfiguration.GlobalPathablesEnabled.Value; ;
+            _rootNode.Checked = PackInitiator.PackState.UserConfiguration.GlobalPathablesEnabled.Value;
         }
 
         public async Task<(List<PathingCategory> categories, int skipped)> SearchAsync(string input, CancellationToken cancellationToken = default, bool forceShowAll = false)
@@ -225,6 +226,7 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeView
 
             return showAllSkippedCategories;
         }
+
         public void NavigateToPath(string path) {
             if(_rootNode == null) return;
 
@@ -285,6 +287,21 @@ namespace BhModule.Community.Pathing.UI.Controls.TreeView
             if (node != null) {
                 node.Checked = active;
             }
+        }
+
+        public void SkipNextStateCheck(PathingCategoryNode node) {
+            _skipStateCheckNode = node;
+        }
+
+        public void UpdateSearchResultsCheckState(IPackState packState) {
+            foreach (var node in AllBaseNodes) {
+                if (node is PathingCategoryNode { IsSearchResult: true, Checkable: true } categoryNode && categoryNode != _skipStateCheckNode) {
+                    categoryNode.Checked = !packState.CategoryStates.GetCategoryInactive(categoryNode.PathingCategory);
+                    categoryNode.Active = !packState.CategoryStates.GetNamespaceInactive(categoryNode.PathingCategory.Namespace);
+                }
+            }
+
+            _skipStateCheckNode = null;
         }
 
         protected override void OnResized(ResizedEventArgs e) {

--- a/UI/Presenters/CategoryTreePresenter.cs
+++ b/UI/Presenters/CategoryTreePresenter.cs
@@ -91,7 +91,12 @@ namespace BhModule.Community.Pathing.UI.Presenter {
             _module.PackInitiator.LoadMapFromEachPackStarted                       += PackInitiatorOnLoadMapFromEachPackStarted;
             _module.PackInitiator.LoadMapFromEachPackFinished                      += PackInitiatorOnLoadMapFromEachPackFinished;
             _module.PackInitiator.PackState.CategoryStates.CategoryInactiveChanged += CategoryStatesOnCategoryInactiveChanged;
+            _module.PackInitiator.PackState.CategoryStates.CategoryStatesOptimized += CategoryStatesOnCategoryStatesOptimized;
             _packEventsInitialized                                                     =  true;
+        }
+
+        private void CategoryStatesOnCategoryStatesOptimized(object sender, EventArgs e) {
+            this.View.TreeView?.UpdateSearchResultsCheckState(_module.PackInitiator.PackState);
         }
 
         private void CategoryStatesOnCategoryInactiveChanged(object sender, PathingCategoryEventArgs e) {

--- a/UI/Tooltips/CategoryPathTooltip.cs
+++ b/UI/Tooltips/CategoryPathTooltip.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BhModule.Community.Pathing.State;
+using Blish_HUD;
+using Blish_HUD.Common.UI.Views;
+using Blish_HUD.Content;
+using Blish_HUD.Controls;
+using Blish_HUD.Graphics.UI;
+using Microsoft.Xna.Framework;
+using TmfLib.Pathable;
+
+namespace BhModule.Community.Pathing.UI.Tooltips
+{
+    internal class CategoryPathTooltip : View, ITooltipView
+    {
+        private readonly PathingCategory _category;
+        private readonly IPackState _packState;
+
+        protected FormattedLabel Text { get; set; }
+        public CategoryPathTooltip(PathingCategory category, IPackState packState) {
+            _category       = category;
+            _packState = packState;
+        }
+
+        protected override void Build(Container buildPanel)
+        {
+            var container = new Panel()
+            {
+                Parent            = buildPanel,
+                ShowBorder        = false,
+                BackgroundTexture = GameService.Content.GetTexture("tooltip"),
+                HeightSizingMode  = SizingMode.AutoSize,
+                WidthSizingMode   = SizingMode.AutoSize,
+                ClipsBounds       = false,
+                ZIndex            = int.MaxValue - 2
+            };
+
+            var builder = new FormattedLabelBuilder();
+
+            var parents = this._category
+                              .GetParentsDesc();
+
+            var firstParent = true;
+
+            foreach (var parent in parents)
+            {
+                var color = parent == this._category ? Color.LightBlue : firstParent ? Color.Orange : Color.LightYellow;
+
+                var inactive = _packState.CategoryStates.GetCategoryInactive(parent);
+                builder = builder.CreatePart($" {parent.DisplayName}\n ", b => b.SetFontSize(ContentService.FontSize.Size16).SetTextColor(color).SetPrefixImage(AsyncTexture2D.FromAssetId(inactive ? 154982 : 154979)).SetPrefixImageSize(new Point(20, 20)));
+
+                firstParent = false;
+            }
+
+            Text = builder
+                  .SetWidth(420)
+                  .AutoSizeHeight()
+                  .Wrap()
+                  .Build();
+
+            Text.Location = new Point(15, 15);
+            Text.Parent   = container;
+        }
+
+        protected override void Unload()
+        {
+            Text?.Dispose();
+
+            base.Unload();
+        }
+    }
+}

--- a/UI/Views/CategoryTreeView.cs
+++ b/UI/Views/CategoryTreeView.cs
@@ -22,9 +22,11 @@ namespace BhModule.Community.Pathing.UI.Views {
 
         private Label _searchStatusLabel;
 
-        public Label _packsNotInitializedLabel;
+        private Label _packsNotInitializedLabel;
 
-        public Label _packsNotLoadedLabel;
+        private Label _packsNotLoadedLabel;
+
+        private Label _helpTextLabel;
 
         private LoadingSpinner _loadingSpinner;
 
@@ -84,13 +86,27 @@ namespace BhModule.Community.Pathing.UI.Views {
                 Visible        = false,
             };
 
+            this._helpTextLabel = new Label()
+            {
+                Parent         = buildPanel,
+                Text           = "Right click on categories for options.",
+                AutoSizeHeight = true,
+                AutoSizeWidth  = true,
+                StrokeText     = true,
+                TextColor      = Color.LightYellow,
+                Font           = GameService.Content.DefaultFont16,
+            };
+
             this.RepoFlowPanel = new CustomFlowPanel {
-                Size       = new Point(buildPanel.ContentRegion.Width, buildPanel.ContentRegion.Height - _searchBox.Bottom - 5),
+                Size       = new Point(buildPanel.ContentRegion.Width, buildPanel.ContentRegion.Height - _searchBox.Bottom - this._helpTextLabel.Height - 5),
                 Top        = _searchBox.Bottom + 5,
                 CanScroll  = true,
                 ShowBorder = true,
                 Parent     = buildPanel
             };
+
+            this._helpTextLabel.Location = new Point(15, this.RepoFlowPanel.Bottom);
+            
 
             this.TreeView = new TreeView(_module.PackInitiator) {
                 HeightSizingMode = SizingMode.AutoSize,

--- a/UI/Views/ConfirmationView.cs
+++ b/UI/Views/ConfirmationView.cs
@@ -21,13 +21,11 @@ namespace BhModule.Community.Pathing.UI.Views {
         protected BlueButton OpenButton { get; set; }
         protected StandardButton DenyButton { get; set; }
 
-        private TreeView _treeView { get; }
         private PathingCategory _category { get; }
 
         private IPackState _packState { get; }
 
-        public ConfirmationView(TreeView treeView, PathingCategory category, IPackState packState) {
-            this._treeView  = treeView;
+        public ConfirmationView(PathingCategory category, IPackState packState) {
             this._category  = category;
             this._packState = packState;
         }
@@ -52,7 +50,7 @@ namespace BhModule.Community.Pathing.UI.Views {
             var firstParent = true;
 
             foreach (var parent in parents) {
-                var color = firstParent ? Color.Orange : Color.LightYellow;
+                var color = parent == this._category ? Color.LightBlue : firstParent ? Color.Orange : Color.LightYellow;
 
                 var inactive = _packState.CategoryStates.GetCategoryInactive(parent);
                 builder = builder.CreatePart($" {parent.DisplayName}\n ", b => b.SetFontSize(ContentService.FontSize.Size16).SetTextColor(color).SetPrefixImage(AsyncTexture2D.FromAssetId(inactive ? 154982 : 154979)).SetPrefixImageSize(new Point(20, 20)));
@@ -83,9 +81,6 @@ namespace BhModule.Community.Pathing.UI.Views {
                 {
                     _packState.CategoryStates.SetInactive(parent, false);
                 }
-
-                //if (_treeView != null)
-                //    _treeView.UpdateSearchResultsCheckState(_packState);
 
                 buildPanel.Dispose();
             };

--- a/UI/Views/ConfirmationView.cs
+++ b/UI/Views/ConfirmationView.cs
@@ -1,0 +1,119 @@
+﻿using System.Linq;
+using BhModule.Community.Pathing.Entity;
+using BhModule.Community.Pathing.State;
+using BhModule.Community.Pathing.UI.Controls;
+using BhModule.Community.Pathing.UI.Controls.TreeView;
+using BhModule.Community.Pathing.Utility;
+using Blish_HUD;
+using Blish_HUD.Content;
+using Blish_HUD.Controls;
+using Microsoft.Xna.Framework;
+using TmfLib.Pathable;
+using Panel = Blish_HUD.Controls.Panel;
+using View = Blish_HUD.Graphics.UI.View;
+
+namespace BhModule.Community.Pathing.UI.Views {
+    internal class ConfirmationView : View {
+        protected FormattedLabel Text { get; set; }
+
+        protected StandardButton ConfirmButton { get; set; }
+        
+        protected BlueButton OpenButton { get; set; }
+        protected StandardButton DenyButton { get; set; }
+
+        private TreeView _treeView { get; }
+        private PathingCategory _category { get; }
+
+        private IPackState _packState { get; }
+
+        public ConfirmationView(TreeView treeView, PathingCategory category, IPackState packState) {
+            this._treeView  = treeView;
+            this._category  = category;
+            this._packState = packState;
+        }
+
+        protected override void Build(Container buildPanel) {
+            var container = new Panel() {
+                Parent            = buildPanel,
+                ShowBorder        = true,
+                BackgroundTexture = GameService.Content.GetTexture("tooltip"),
+                Size              = buildPanel.Size,
+                ClipsBounds       = false,
+                HeightSizingMode  = SizingMode.AutoSize,
+                ZIndex            = int.MaxValue - 2
+            };
+
+            var builder = new FormattedLabelBuilder()
+                         .CreatePart("Do you wish to activate all the parents of this category?",                           b => b.SetFontSize(ContentService.FontSize.Size18).SetTextColor(Color.Orange).MakeBold())
+                         .CreatePart("\n \nThe category you selected is not active because one or more of the parent categories listed below is not active.\n \n ", b => b.SetFontSize(ContentService.FontSize.Size16));
+
+            var parents = this._category.GetParentsDesc().ToList();
+
+            var firstParent = true;
+
+            foreach (var parent in parents) {
+                var color = firstParent ? Color.Orange : Color.LightYellow;
+
+                var inactive = _packState.CategoryStates.GetCategoryInactive(parent);
+                builder = builder.CreatePart($" {parent.DisplayName}\n ", b => b.SetFontSize(ContentService.FontSize.Size16).SetTextColor(color).SetPrefixImage(AsyncTexture2D.FromAssetId(inactive ? 154982 : 154979)).SetPrefixImageSize(new Point(20, 20)));
+
+                firstParent = false;
+            }
+
+            Text = builder
+                  .SetWidth(344)
+                  .AutoSizeHeight()
+                  .Wrap()
+                  .Build();
+
+            Text.Location = new Point(15, 15);
+            Text.Parent   = container;
+            
+            ConfirmButton = new StandardButton()
+            {
+                Parent   = container,
+                Text     = "Yes",
+                Width    = 85,
+                Location = new Point(15, Text.Height + 30)
+            };
+
+            ConfirmButton.Click += (_, _) =>
+            {
+                foreach(var parent in parents)
+                {
+                    _packState.CategoryStates.SetInactive(parent, false);
+                }
+
+                //if (_treeView != null)
+                //    _treeView.UpdateSearchResultsCheckState(_packState);
+
+                buildPanel.Dispose();
+            };
+
+            DenyButton = new StandardButton()
+            {
+                Parent   = container,
+                Text     = "Cancel",
+                Width    = 85,
+                Location = new Point(ConfirmButton.Right + 5, Text.Height + 30)
+            };
+
+            DenyButton.Click += (_, _) => buildPanel.Dispose();
+
+
+            OpenButton = new BlueButton()
+            {
+                Parent   = container,
+                Text     = "Open In Explorer",
+                Width    = 150,
+                Location = new Point(DenyButton.Right + 50, Text.Height + 30)
+            };
+
+            OpenButton.Click += (_, _) => {
+                _packState.CategoryStates.TriggerOpenCategory(_category);
+                buildPanel.Dispose();
+            };
+
+        }
+    }
+}


### PR DESCRIPTION
## Discussion Reference
https://discord.com/channels/531175899588984842/1373095160824598639/1378216432004763758

## Is this a breaking change?
No


## Includes the following changes:
- The main dropdown now has a search "Search" option under "All Markers" that opens the Category Explorer in the settings window.
- The pack name of each category is now displayed in the search results (orange color).
- If you activate a category, but one of the parent categories is disabled, you will now see a popup to automatically enable all the parent categories. This only works in the category explorer, not in the main dropdown.
- Search results now display a tooltip that shows the category path (hover over category name or pack name).
- A label has been added at the bottom "Right click on categories for more options" in the category explorer window.
- Fixed a null reference issue related to textures.

![image](https://github.com/user-attachments/assets/fff05b78-2152-49fb-8129-8b8b8249fd71)
